### PR TITLE
fix: add kafka bootstrap servers to schema-registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - "postgres"
       - "-c"
       - "wal_level=logical"  
+
   zookeeper:
     image: debezium/zookeeper:latest
     ports:
@@ -35,17 +36,20 @@ services:
      - zookeeper
     environment:
      - ZOOKEEPER_CONNECT=zookeeper:2181
+
   schema-registry:
     image: confluentinc/cp-schema-registry
     ports:
       - 8181:8181
       - 8081:8081
     environment:
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=kafka:9092
       - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry
       - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
     links:
       - zookeeper  
+
   connect:
     image: debezium/connect:latest
     ports:


### PR DESCRIPTION
Minor fix for schema-registry service. Container startup failed without that env variable.